### PR TITLE
feat: Add DND Settings tile to open system DND automation settings

### DIFF
--- a/app/src/main/java/dev/robin/flip_2_dnd/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/robin/flip_2_dnd/presentation/settings/SettingsScreen.kt
@@ -1921,6 +1921,24 @@ fun SettingsContent(
                         }
                     },
                 )
+
+                SettingsClickableItem(
+                    title = stringResource(id = R.string.dnd_settings),
+                    description = stringResource(id = R.string.dnd_settings_description),
+                    onClick = {
+                        try {
+                            val intent = Intent("android.settings.ZEN_MODE_AUTOMATION_SETTINGS")
+                            context.startActivity(intent)
+                        } catch (e: ActivityNotFoundException) {
+                            Toast
+                                .makeText(
+                                    context,
+                                    R.string.error_opening_dnd_settings,
+                                    Toast.LENGTH_SHORT,
+                                ).show()
+                        }
+                    },
+                )
             }
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,9 @@
 	<string name="general">General</string>
 	<string name="language">Language</string>
 	<string name="language_description">Change the app language</string>
+	<string name="dnd_settings">DND Settings</string>
+	<string name="dnd_settings_description">Manage Do Not Disturb exceptions and filters</string>
+	<string name="error_opening_dnd_settings">Could not open DND settings</string>
 	<string name="error_opening_language_settings">Could not open language settings</string>
 	<string name="qs_tile_label">Flip DND service</string>
 	<string name="detection">Detection</string>


### PR DESCRIPTION
This adds a clickable tile in the General settings section that opens
the system DND automation/rules settings where the app's managed DND
mode is displayed.

closes #59